### PR TITLE
feat: add fullscreen toggle to BaseSandpack

### DIFF
--- a/src/components/sandpacks/base/BaseSandpack.jsx
+++ b/src/components/sandpacks/base/BaseSandpack.jsx
@@ -1,14 +1,35 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSearchParams } from 'react-router-dom';
 import { Sandpack } from '@codesandbox/sandpack-react';
 import { githubLight, monokaiPro, sandpackDark } from '@codesandbox/sandpack-themes';
+import { Maximize, Minimize } from 'lucide-react';
+import '../styles/BaseSandpack.css';
 
 function BaseSandpack({ template, files, options }) {
   const [searchParams] = useSearchParams();
   const height = searchParams.get('height') || '99.5vh';
   const console = Boolean(searchParams.get('console')) || false;
   const themeName = searchParams.get('theme') || 'light';
+
+  const containerRef = useRef(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === containerRef.current);
+    };
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      containerRef.current?.requestFullscreen?.();
+    } else {
+      document.exitFullscreen?.();
+    }
+  };
 
   const theme = {
     light: { ...githubLight, font: { ...githubLight.font, size: '14.4px' } },
@@ -17,20 +38,31 @@ function BaseSandpack({ template, files, options }) {
   };
 
   return (
-    <Sandpack
-      template={template}
-      theme={theme[themeName]}
-      files={files}
-      options={{
-        editorHeight: height,
-        showLineNumbers: true,
-        showConsole: console,
-        showConsoleButton: true,
-        editorWidthPercentage: 65,
-        resizablePanels: true,
-        ...options,
-      }}
-    />
+    <div ref={containerRef} className="base-sandpack-container">
+      <button
+        type="button"
+        className="base-sandpack-fullscreen-btn"
+        onClick={toggleFullscreen}
+        aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+        title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+      >
+        {isFullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
+      </button>
+      <Sandpack
+        template={template}
+        theme={theme[themeName]}
+        files={files}
+        options={{
+          editorHeight: height,
+          showLineNumbers: true,
+          showConsole: console,
+          showConsoleButton: true,
+          editorWidthPercentage: 65,
+          resizablePanels: true,
+          ...options,
+        }}
+      />
+    </div>
   );
 }
 

--- a/src/components/sandpacks/styles/BaseSandpack.css
+++ b/src/components/sandpacks/styles/BaseSandpack.css
@@ -1,0 +1,29 @@
+.base-sandpack-container {
+  position: relative;
+}
+
+.base-sandpack-container:fullscreen .sp-wrapper {
+  height: 100vh !important;
+}
+
+.base-sandpack-fullscreen-btn {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.base-sandpack-fullscreen-btn:hover {
+  background: rgba(0, 0, 0, 0.8);
+}


### PR DESCRIPTION
## Summary
- Adds a fullscreen toggle button (bottom-left of the Sandpack) that uses the browser's native Fullscreen API.
- Keeps fullscreen state in sync with `fullscreenchange` so pressing Esc updates the icon.
- Adds `BaseSandpack.css` with a `:fullscreen` override that forces `.sp-wrapper` to `100vh`, so the editor fills the screen regardless of the configured `editorHeight` (e.g. when `?height=400px`).

## Test plan
- [ ] Open any embed using `BaseSandpack`, click the Maximize button — sandpack expands to full viewport.
- [ ] Click the Minimize button (or press Esc) — sandpack returns to its prior size, icon flips back to Maximize.
- [ ] Try with `?height=400px` and verify the editor fills the screen while in fullscreen.
- [ ] Try with `?theme=dark` and `?theme=monokai` and confirm the button stays readable.