### PR TITLE
feat(sql-play): SQL Playground creator page

### DIFF
--- a/src/components/activities/commons/AccessibleFormField.css
+++ b/src/components/activities/commons/AccessibleFormField.css
@@ -185,7 +185,7 @@ legend {
 
 /* Header styling */
 header {
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
 }
 
 header h1 {
@@ -230,15 +230,15 @@ header p {
   .form-field__input-with-button {
     flex-direction: column;
   }
-  
+
   .form-field__button {
     width: 100%;
   }
-  
+
   .form-actions .form-field__button {
     align-self: stretch;
   }
-  
+
   .creation-preview {
     max-height: none;
   }

--- a/src/components/activities/commons/ActivitiesContainer.jsx
+++ b/src/components/activities/commons/ActivitiesContainer.jsx
@@ -38,7 +38,7 @@ export default function ActivitiesContainer({ children, title = 'Komponen Intera
           </div>
           <div className="activities__buttons">
             <button type="button" className="activities__buttons-item theme-switch" onClick={() => toggleTheme()}>
-              {theme === 'dark' ? <Sun /> : <Moon />}
+              {theme === 'dark' ? <Moon /> : <Sun />}
             </button>
           </div>
         </div>

--- a/src/components/activities/commons/LoadFromBase64.jsx
+++ b/src/components/activities/commons/LoadFromBase64.jsx
@@ -31,7 +31,8 @@ function LoadFromBase64({ onLoad, activityType }) {
       const expectedKeys = {
         'fill-in-the-blank': ['template', 'answers'],
         'flashcards': ['cards'],
-        'drag-and-order': ['items']
+        'drag-and-order': ['items'],
+        'sql-playground': ['setupSql', 'defaultQuery'],
       };
 
       const requiredKeys = expectedKeys[activityType];

--- a/src/components/activities/sql-playground/style.css
+++ b/src/components/activities/sql-playground/style.css
@@ -132,6 +132,7 @@
 /* Tab Content */
 .sql-playground__tab-content {
   flex: 1;
+  max-height: 360px;
   overflow: auto;
   padding: 16px;
   background-color: var(--card-bg);

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -29,6 +29,11 @@ function HomePage() {
               <h3>Drag and Order</h3>
               <p>Buat aktivitas drag and drop untuk mengurutkan item</p>
             </a>
+
+            <a href="/activities/sql-playground/create" className="homepage__card">
+              <h3>SQL Playground</h3>
+              <p>Buat aktivitas drag and drop untuk mengurutkan item</p>
+            </a>
           </div>
         </section>
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -13,18 +13,18 @@ function HomePage() {
         <section className="homepage__section">
           <h2>Interactive Activities</h2>
           <p>Buat aktivitas pembelajaran interaktif untuk meningkatkan engagement siswa</p>
-          
+
           <div className="homepage__cards">
             <a href="/activities/fill-in-the-blank/create" className="homepage__card">
               <h3>Fill in the Blank</h3>
               <p>Buat aktivitas isian kosong dengan placeholder dan validasi jawaban</p>
             </a>
-            
+
             <a href="/activities/flashcards/create" className="homepage__card">
               <h3>Flashcards</h3>
               <p>Buat kartu belajar interaktif dengan rich text editor</p>
             </a>
-            
+
             <a href="/activities/drag-and-order/create" className="homepage__card">
               <h3>Drag and Order</h3>
               <p>Buat aktivitas drag and drop untuk mengurutkan item</p>
@@ -32,7 +32,7 @@ function HomePage() {
 
             <a href="/activities/sql-playground/create" className="homepage__card">
               <h3>SQL Playground</h3>
-              <p>Buat aktivitas drag and drop untuk mengurutkan item</p>
+              <p>Buat playground SQL interaktif dengan skema dan data Anda sendiri.</p>
             </a>
           </div>
         </section>
@@ -40,7 +40,7 @@ function HomePage() {
         <section className="homepage__section">
           <h2>Embed Code Generator</h2>
           <p>Generate embed code untuk konten Dicoding Sandpack lainnya</p>
-          
+
           <div className="homepage__cards">
             <a href="/embed-generator" className="homepage__card">
               <h3>Sandpack Embed Generator</h3>

--- a/src/pages/activities/index.jsx
+++ b/src/pages/activities/index.jsx
@@ -6,6 +6,7 @@ import DragAndOrderPage from './drag-and-orders/DragAndOrderPage';
 import FillInBlankCreationPage from './fill-in-the-blanks/CreationPage';
 import FillInTheBlankPage from './fill-in-the-blanks/FillInTheBlankPage';
 import PlaygroundPage from './sql-playground/PlaygroundPage';
+import SqlPlaygroundCreationPage from './sql-playground/CreationPage';
 
 export const activitiesRoutes = [
   {
@@ -35,5 +36,9 @@ export const activitiesRoutes = [
   {
     path: '/activities/sql-playground',
     element: <PlaygroundPage />,
+  },
+  {
+    path: '/activities/sql-playground/create',
+    element: <SqlPlaygroundCreationPage />,
   },
 ];

--- a/src/pages/activities/sql-playground/CreationPage.jsx
+++ b/src/pages/activities/sql-playground/CreationPage.jsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import SqlPlayground, {
+  DEFAULT_SETUP_SQL,
+  DEFAULT_QUERY,
+} from '../../../components/activities/sql-playground';
+import ResizableLayout from '../../../components/activities/commons/ResizableLayout';
+import AccessibleFormField from '../../../components/activities/commons/AccessibleFormField';
+import LoadFromBase64 from '../../../components/activities/commons/LoadFromBase64';
+import { generateIframe, unicodeToBase64 } from '../../../utils';
+import useInput from '../../../hooks/useInput';
+
+export default function CreationPage() {
+  const [setupSql, setSetupSql] = useState(DEFAULT_SETUP_SQL.trim());
+  const [defaultQuery, setDefaultQuery] = useState(DEFAULT_QUERY);
+  const [instruction, setInstruction] = useState('');
+  const [height, onHeightChange] = useInput('630');
+  const [embedCode, setEmbedCode] = useState('');
+
+  const handleLoadFromBase64 = (data) => {
+    if (typeof data.setupSql === 'string') setSetupSql(data.setupSql);
+    if (typeof data.defaultQuery === 'string') setDefaultQuery(data.defaultQuery);
+    if (typeof data.instruction === 'string') setInstruction(data.instruction);
+  };
+
+  const generateEmbedCode = () => {
+    if (!setupSql.trim()) {
+      // eslint-disable-next-line no-alert
+      alert('Setup SQL tidak boleh kosong');
+      return;
+    }
+
+    const data = unicodeToBase64(JSON.stringify({ setupSql, defaultQuery, instruction }));
+    const src = `${window.location.protocol}//${window.location.host}/activities/sql-playground?data=${encodeURIComponent(data)}`;
+
+    setEmbedCode(generateIframe(src, 'Dicoding Learning Activities - SQL Playground', height));
+  };
+
+  const formPanel = (
+    <div className="creation-form">
+      <header>
+        <h1>SQL Playground Generator</h1>
+        <p>Buat playground SQL interaktif dengan skema dan data awal Anda sendiri</p>
+      </header>
+
+      <LoadFromBase64
+        onLoad={handleLoadFromBase64}
+        activityType="sql-playground"
+      />
+
+      <form onSubmit={(e) => e.preventDefault()}>
+        <AccessibleFormField
+          id="setup-sql"
+          label="Setup SQL"
+          type="textarea"
+          value={setupSql}
+          onChange={(e) => setSetupSql(e.target.value)}
+          placeholder="CREATE TABLE ...; INSERT INTO ...;"
+          helpText="Perintah SQL untuk membuat skema dan mengisi data awal. Dijalankan saat playground dimuat dan saat di-reset."
+          rows={12}
+          required
+        />
+
+        <AccessibleFormField
+          id="default-query"
+          label="Default Query"
+          type="textarea"
+          value={defaultQuery}
+          onChange={(e) => setDefaultQuery(e.target.value)}
+          placeholder="SELECT * FROM ...;"
+          helpText="Query yang muncul di editor saat playground pertama kali dibuka."
+          rows={6}
+        />
+
+        <AccessibleFormField
+          id="instruction"
+          label="Instruction Text"
+          value={instruction}
+          onChange={(e) => setInstruction(e.target.value)}
+          placeholder="Instruksi yang ditampilkan kepada siswa (opsional)"
+          helpText="Teks instruksi opsional yang ditampilkan di atas playground."
+        />
+
+        <AccessibleFormField
+          id="height"
+          label="Height (pixels)"
+          type="number"
+          value={height}
+          onChange={onHeightChange}
+          helpText="Tinggi iframe dalam pixel"
+          min="300"
+          max="1200"
+        />
+
+        <div className="form-actions">
+          <button
+            type="button"
+            className="form-field__button form-field__button--primary"
+            onClick={generateEmbedCode}
+          >
+            Generate Embed Code
+          </button>
+        </div>
+
+        <AccessibleFormField
+          id="embed-code"
+          label="Embed Code"
+          type="textarea"
+          value={embedCode}
+          readOnly
+          placeholder="Embed code akan muncul di sini setelah generate"
+          helpText="Salin kode ini untuk menyematkan aktivitas di halaman web"
+          rows={4}
+        />
+      </form>
+    </div>
+  );
+
+  const previewPanel = (
+    <div className="creation-preview">
+      <header>
+        <h2>Preview</h2>
+        <p>Pratinjau SQL playground yang akan dibuat</p>
+      </header>
+
+      <div role="region" aria-label="SQL Playground preview">
+        <SqlPlayground
+          setupSql={setupSql}
+          defaultQuery={defaultQuery}
+          instructionsText={instruction}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <ResizableLayout
+      leftPanel={formPanel}
+      rightPanel={previewPanel}
+      initialLeftWidth={45}
+    />
+  );
+}

--- a/src/pages/activities/sql-playground/CreationPage.jsx
+++ b/src/pages/activities/sql-playground/CreationPage.jsx
@@ -15,7 +15,7 @@ export default function CreationPage() {
   const [setupSql, setSetupSql] = useState(INITIAL_SETUP_SQL);
   const [defaultQuery, setDefaultQuery] = useState(DEFAULT_QUERY);
   const [instruction, setInstruction] = useState('');
-  const [height, onHeightChange] = useInput('630');
+  const [height, onHeightChange] = useInput('600');
   const [embedCode, setEmbedCode] = useState('');
 
   // The values that actually drive the preview. Updated only via "Apply" so

--- a/src/pages/activities/sql-playground/CreationPage.jsx
+++ b/src/pages/activities/sql-playground/CreationPage.jsx
@@ -9,17 +9,41 @@ import LoadFromBase64 from '../../../components/activities/commons/LoadFromBase6
 import { generateIframe, unicodeToBase64 } from '../../../utils';
 import useInput from '../../../hooks/useInput';
 
+const INITIAL_SETUP_SQL = DEFAULT_SETUP_SQL.trim();
+
 export default function CreationPage() {
-  const [setupSql, setSetupSql] = useState(DEFAULT_SETUP_SQL.trim());
+  const [setupSql, setSetupSql] = useState(INITIAL_SETUP_SQL);
   const [defaultQuery, setDefaultQuery] = useState(DEFAULT_QUERY);
   const [instruction, setInstruction] = useState('');
   const [height, onHeightChange] = useInput('630');
   const [embedCode, setEmbedCode] = useState('');
 
+  // The values that actually drive the preview. Updated only via "Apply" so
+  // editing the schema doesn't rebuild the in-browser Postgres on every keystroke.
+  const [preview, setPreview] = useState({
+    setupSql: INITIAL_SETUP_SQL,
+    defaultQuery: DEFAULT_QUERY,
+    instruction: '',
+  });
+
+  const isPreviewStale = setupSql !== preview.setupSql
+    || defaultQuery !== preview.defaultQuery
+    || instruction !== preview.instruction;
+
+  const applyPreview = () => {
+    setPreview({ setupSql, defaultQuery, instruction });
+  };
+
   const handleLoadFromBase64 = (data) => {
-    if (typeof data.setupSql === 'string') setSetupSql(data.setupSql);
-    if (typeof data.defaultQuery === 'string') setDefaultQuery(data.defaultQuery);
-    if (typeof data.instruction === 'string') setInstruction(data.instruction);
+    const next = {
+      setupSql: typeof data.setupSql === 'string' ? data.setupSql : setupSql,
+      defaultQuery: typeof data.defaultQuery === 'string' ? data.defaultQuery : defaultQuery,
+      instruction: typeof data.instruction === 'string' ? data.instruction : instruction,
+    };
+    setSetupSql(next.setupSql);
+    setDefaultQuery(next.defaultQuery);
+    setInstruction(next.instruction);
+    setPreview(next);
   };
 
   const generateEmbedCode = () => {
@@ -122,11 +146,27 @@ export default function CreationPage() {
         <p>Pratinjau SQL playground yang akan dibuat</p>
       </header>
 
+      <div className="form-actions">
+        <button
+          type="button"
+          className="form-field__button form-field__button--primary"
+          onClick={applyPreview}
+          disabled={!isPreviewStale}
+        >
+          Perbarui Pratinjau
+        </button>
+        {isPreviewStale && (
+          <span className="form-field__help">
+            Pratinjau belum sesuai dengan perubahan terbaru. Klik untuk memperbarui.
+          </span>
+        )}
+      </div>
+
       <div role="region" aria-label="SQL Playground preview">
         <SqlPlayground
-          setupSql={setupSql}
-          defaultQuery={defaultQuery}
-          instructionsText={instruction}
+          setupSql={preview.setupSql}
+          defaultQuery={preview.defaultQuery}
+          instructionsText={preview.instruction}
         />
       </div>
     </div>


### PR DESCRIPTION
## What

Adds the **authoring/creator page** for the SQL Playground activity at `/activities/sql-playground/create`, the companion to the viewer shipped in #79. Content authors define a schema + seed data and a default query, preview it live, and generate an embeddable iframe.

## Changes

- **`CreationPage.jsx`** (new) — split-pane authoring UI (`ResizableLayout`):
  - Fields: **Setup SQL**, **Default Query**, **Instruction** (optional), **Height**.
  - Generates a `/activities/sql-playground?data=<base64>` iframe via `unicodeToBase64` + `generateIframe`.
  - **Load from Base64** to re-import an existing embed for editing (applies to the form and preview together).
  - **Live preview** driven by an explicit **"Perbarui Pratinjau"** button rather than on every keystroke — editing the schema no longer rebuilds the in-browser Postgres per character (it would `PGlite.create()` on each keystroke). The button is disabled when the preview is in sync and shows a stale hint otherwise.
- **Route + entry point** — register the `/create` route (`pages/activities/index.jsx`) and add a card link on the home page.
- **`LoadFromBase64`** — add the `sql-playground` validation key (`['setupSql', 'defaultQuery']`).
- **`style.css`** — cap `.sql-playground__tab-content` height so large Schema/Data/result sets scroll internally instead of stretching the widget.

## Heads-up for reviewers

- **`ActivitiesContainer.jsx`** flips the theme-toggle icon (`dark ? Moon : Sun`). This is a **shared component**, so the change affects all activities (Flashcards, Fill-in-the-Blank, Drag-and-Order), not just SQL Playground. Intentional ("show theme icon correctly").
- **`AccessibleFormField.css`** reduces the shared creation-page header `margin-bottom` (2rem → 1.25rem), which applies to all activity creators.
- Pre-existing lint issues in `LoadFromBase64.jsx` are unrelated to this change (untouched lines); the new files lint clean.

## Testing

- `vite build` — passes.
- Lint — clean on the new/changed files for this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)