### PR TITLE
feat: allow SQL playground with empty setup SQL

### DIFF
--- a/src/pages/activities/sql-playground/CreationPage.jsx
+++ b/src/pages/activities/sql-playground/CreationPage.jsx
@@ -47,12 +47,6 @@ export default function CreationPage() {
   };
 
   const generateEmbedCode = () => {
-    if (!setupSql.trim()) {
-      // eslint-disable-next-line no-alert
-      alert('Setup SQL tidak boleh kosong');
-      return;
-    }
-
     const data = unicodeToBase64(JSON.stringify({ setupSql, defaultQuery, instruction }));
     const src = `${window.location.protocol}//${window.location.host}/activities/sql-playground?data=${encodeURIComponent(data)}`;
 
@@ -79,9 +73,8 @@ export default function CreationPage() {
           value={setupSql}
           onChange={(e) => setSetupSql(e.target.value)}
           placeholder="CREATE TABLE ...; INSERT INTO ...;"
-          helpText="Perintah SQL untuk membuat skema dan mengisi data awal. Dijalankan saat playground dimuat dan saat di-reset."
+          helpText="Perintah SQL untuk membuat skema dan mengisi data awal. Dijalankan saat playground dimuat dan saat di-reset. Boleh dikosongkan untuk memulai tanpa skema."
           rows={12}
-          required
         />
 
         <AccessibleFormField

--- a/src/pages/activities/sql-playground/PlaygroundPage.jsx
+++ b/src/pages/activities/sql-playground/PlaygroundPage.jsx
@@ -18,7 +18,7 @@ export default function PlaygroundPage() {
 
     return (
       <SqlPlayground
-        setupSql={setupSql || undefined}
+        setupSql={typeof setupSql === 'string' ? setupSql : undefined}
         defaultQuery={defaultQuery || undefined}
         instructionsText={instruction}
       />


### PR DESCRIPTION
## What

Allow authoring an SQL Playground activity that starts **without any setup schema**.

## Changes

- **`CreationPage.jsx`** — removed the non-empty validation guard on Setup SQL (the `alert` blocking generation) and dropped the inert `required` attribute. Help text now notes the field may be left empty.
- **`PlaygroundPage.jsx`** — changed `setupSql={setupSql || undefined}` to `setupSql={typeof setupSql === 'string' ? setupSql : undefined}`. Previously an explicitly empty `setupSql` was coerced to `undefined`, which triggered the component's `defaultProps` and silently restored the full default schema. Now an empty string flows through to `createDatabase('')` (no tables), while a missing key still falls back to the default schema.

## Notes

- The bare `/activities/sql-playground` route (no `data` param) still uses the default schema — unchanged.
- Verified locally with `eslint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)